### PR TITLE
[Moon Phase System]

### DIFF
--- a/Labs/Scenes/Level Components/Time/level_time_component.gd
+++ b/Labs/Scenes/Level Components/Time/level_time_component.gd
@@ -1,8 +1,8 @@
 class_name TimeComponent extends Node
 ## The Fourth Dimension.
 
-@export var INGAME_SPEED : float = 1.0
-@export var INITIAL_HOUR : int = 5:
+@export var INGAME_SPEED : float = 0.1
+@export var INITIAL_HOUR : int = 18:
 	set(h):
 		INITIAL_HOUR = h
 		current_time = INGAME_TO_REAL_MINUTE_DURATION * INITIAL_HOUR * MINUTES_PER_HOUR

--- a/Labs/Scenes/Level Components/Time/world_time_component.gd
+++ b/Labs/Scenes/Level Components/Time/world_time_component.gd
@@ -4,6 +4,7 @@ extends TimeComponent
 
 func _ready():
 	INGAME_SPEED = 0.1  ## 10 real-life minutes per in-game hour.
+	INITIAL_HOUR = 12
 	current_time = INGAME_TO_REAL_MINUTE_DURATION * INITIAL_HOUR * MINUTES_PER_HOUR
 
 

--- a/Labs/Scenes/Level Components/Weather/DayNight/day_night_component.gd
+++ b/Labs/Scenes/Level Components/Weather/DayNight/day_night_component.gd
@@ -6,7 +6,7 @@ class_name DayNightComponent extends Node2D
 
 @export var lighting : ColorRect = null
 @export var sunrays  : ColorRect = null
-@export var camera   : Node2D    = null   ## NOTE - Stay NULL. Grabs Caferino's current player's camera in script.
+@export var camera   : Node2D    = null   ## NOTE - Stay NULL. Grabs Caferino.gd's current player's camera in script.
 @export var cycle    : GradientTexture1D = null
 @onready var tween   : Tween = create_tween().set_parallel(true)  ## Animates the sun rays parameters.
 
@@ -16,7 +16,7 @@ var texture : Texture = ImageTexture.new()
 
 func _ready():
 	tween.kill()    ## Avoids a weird error where @onready tweens must be used quickly
-	visible = true  ## Just so I can hide it in the Inspector and not have everything dark
+	visible = true  ## Just so I can hide it in the Inspector and not have everything dark.
 	SignalManager.time_tick.connect(handle_light)
 	image = Image.create_empty(128, 2, false, Image.FORMAT_RGBAH)
 	camera = Caferino.player.controller.camera_base.camera
@@ -70,7 +70,7 @@ func _update_texture():
 ## If I ever seek to control the speed and increase it for cutscenes or 
 ## weird time spells, taking the INGAME_SPEED into account here fixes that.
 ## TODO - Moon Phases can just affect the Night and Midnight's Color's Alpha value.
-func handle_light(_day: int, hour: int, minute: int) -> void:
+func handle_light(day: int, hour: int, minute: int) -> void:
 	#print("Day: ", day, ", Hour: ", hour, ", Minute: ", minute)  # DEBUG
 	if minute == 0:
 		if hour == 6:     ## 6:00 A.M.  -  MORNING
@@ -78,9 +78,11 @@ func handle_light(_day: int, hour: int, minute: int) -> void:
 		elif hour == 9:   ## 9:00 A.M.  -  NOON
 			set_shader_params(Color(1.0, 0.9, 0.65, 0.8), 0.1, 1.0, 0.22, 1.0, 0.16, 1.0)
 		elif hour == 18:  ## 6:00 P.M.  -  NIGHT
-			set_shader_params(Color(1.0, 0.75, 1.0, 0.5), 1.0, 0.1, 1.0, 0.22, 1.0, 0.16)
+			var moon_phase = get_moon_phase(day)
+			set_shader_params(Color(1.0, 0.75, 1.0, moon_phase), 1.0, 0.1, 1.0, 0.22, 1.0, 0.16)
 		elif hour == 5:   ## 5:00 A.M.  -  MIDNIGHT
-			set_shader_params(Color(1.0, 0.75, 1.0, 0.5), 0.1, 1.0, 0.22, 1.0, 0.16, 1.0)
+			var moon_phase = get_moon_phase(day)
+			set_shader_params(Color(1.0, 0.75, 1.0, moon_phase), 0.1, 1.0, 0.22, 1.0, 0.16, 1.0)
 
 
 func set_shader_params(color: Color, iv_cutoff: float, cutoff: float, iv_falloff: float, falloff: float, iv_edge_fade: float, edge_fade: float) -> void:
@@ -97,3 +99,8 @@ func set_shader_params(color: Color, iv_cutoff: float, cutoff: float, iv_falloff
 	tween.tween_property(sunrays.material, "shader_parameter/falloff", falloff, 60 / WorldTime.INGAME_SPEED)
 	tween.tween_property(sunrays.material, "shader_parameter/edge_fade", edge_fade, 60 / WorldTime.INGAME_SPEED)
 	tween.play()
+
+
+func get_moon_phase(day: int):
+	## Taken from: https://calculator.now/moon-phase-calculator/
+	return (1 - cos((2 * PI * day) / 29.53)) * 50 / 100


### PR DESCRIPTION
Created a very simple and basic Moon Phase System that utilizes the formula given by https://calculator.now/moon-phase-calculator/

At first, I was using the block of code shown in the image, with conditions. I think it is less expensive, however, since the block runs once every few real life hours, I chose to use the accurate formula, for more precision and because I love to go into unnecessary details. I think they can make games more interesting and sexy, like RDR2 and their shrinking balls system, or broken bottle glass reflection distortions, small things like those are very fun to me to dig on.

![Screenshot From 2025-02-10 20-19-00](https://github.com/user-attachments/assets/e08f4c6a-e42c-4cbb-9a75-cb90bb1b9dd5)

The code is now a simple one-line formula that takes into account the current day, and returns the % of illumination the moon must have that night (it has to be on radians to work, which Godot already has as a default, luckily):
moon_illumination = (1 - cos((2 * PI * day) / 29.53)) * 50 / 100   # Normalized to 0.0 - 1.0

I think that shall be enough for everything related to Day and Night. I don't plan to go even further with leap years or stuff like that, but I'd love to someday, not for this game, but whatever merits that scope.